### PR TITLE
Migrating usage of deprecated FirebaseSDK function

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -52,26 +52,28 @@
 
 -(void)initRegistration;
 {
-    NSString * registrationToken = [[FIRInstanceID instanceID] token];
+    [[FIRInstanceID instanceID] instanceIDWithHandler:^(FIRInstanceIDResult * _Nullable result, NSError * _Nullable error) {
 
-    if (registrationToken != nil) {
-        NSLog(@"FCM Registration Token: %@", registrationToken);
-        [self setFcmRegistrationToken: registrationToken];
+        if (error == nil) {
+            NSString * registrationToken = result.token;
+            NSLog(@"FCM Registration Token: %@", registrationToken);
+            [self setFcmRegistrationToken: registrationToken];
 
-        id topics = [self fcmTopics];
-        if (topics != nil) {
-            for (NSString *topic in topics) {
-                NSLog(@"subscribe to topic: %@", topic);
-                id pubSub = [FIRMessaging messaging];
-                [pubSub subscribeToTopic:topic];
+            id topics = [self fcmTopics];
+            if (topics != nil) {
+                for (NSString *topic in topics) {
+                    NSLog(@"subscribe to topic: %@", topic);
+                    id pubSub = [FIRMessaging messaging];
+                    [pubSub subscribeToTopic:topic];
+                }
             }
+
+            [self registerWithToken:registrationToken];
+        } else {
+            NSLog(@"Error fetching remote instance ID: %@", error);
         }
 
-        [self registerWithToken:registrationToken];
-    } else {
-        NSLog(@"FCM token is null");
-    }
-
+    }];
 }
 
 //  FCM refresh token
@@ -80,7 +82,6 @@
 #if !TARGET_IPHONE_SIMULATOR
     // A rotation of the registration tokens is happening, so the app needs to request a new token.
     NSLog(@"The FCM registration token needs to be changed.");
-    [[FIRInstanceID instanceID] token];
     [self initRegistration];
 #endif
 }


### PR DESCRIPTION
The usage of the deprecated method, `FIRInstanceID.token()`, was updated so that this package can support the latest version of the Firebase SDK. Instead, the `instanceIDWithHandler` method is used to retrieve a `FIRInstanceIDResult`, which contains the token.

### Resources
[Firebase iOS SDK Release Notes - Deprecation](https://firebase.google.com/support/release-notes/ios#instance_id)
[Firebase iOS SDK Docs - Fetching registration token](https://firebase.google.com/docs/cloud-messaging/ios/client#objective-c_4)
