### PR TITLE
Migrating usage of deprecated FirebaseSDK class - Android

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java
+++ b/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java
@@ -6,21 +6,18 @@ import android.content.SharedPreferences;
 import android.util.Log;
 
 import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.FirebaseInstanceIdService;
+import com.google.firebase.messaging.FirebaseMessagingService;
 
 import org.json.JSONException;
 
 import java.io.IOException;
 
-public class PushInstanceIDListenerService extends FirebaseInstanceIdService implements PushConstants {
+public class PushInstanceIDListenerService extends FirebaseMessagingService implements PushConstants {
     public static final String LOG_TAG = "Push_InsIdService";
 
     @Override
-    public void onTokenRefresh() {
-        // Get updated InstanceID token.
-        String refreshedToken = FirebaseInstanceId.getInstance().getToken();
-        Log.d(LOG_TAG, "Refreshed token: " + refreshedToken);
-        // TODO: Implement this method to send any registration to your app's servers.
-        //sendRegistrationToServer(refreshedToken);
+    public void onNewToken(String s) {
+        super.onNewToken(s);
+        Log.e(LOG_TAG, s);
     }
 }


### PR DESCRIPTION
As part of making this plugin compatible with the latest version of FirebaseSDK, the usage of the deprecated `FirebaseInstanceIdService` class was migrated.

### Resources
[Firebase Android Docs - FirebaseInstanceIdService Deprecation](https://firebase.google.com/support/release-notes/android#firebase_instance_id_version_1620)