### PR TITLE
Locking Firebase version to 6.25.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -82,7 +82,7 @@
     <source-file src="src/ios/PushPlugin.m"/>
     <header-file src="src/ios/AppDelegate+notification.h"/>
     <header-file src="src/ios/PushPlugin.h"/>
-    <framework src="Firebase/Messaging" type="podspec" spec=""/>
+    <framework src="Firebase/Messaging" type="podspec" spec="6.25.0"/>
     <framework src="PushKit.framework"/>
   </platform>
   <platform name="windows">


### PR DESCRIPTION
Having the Firebase version determined automatically is undesirable since it can result in unexpected conflicts with versions of Firebase used by other plugins in a project. This causes cordova builds to randomly fail.